### PR TITLE
deps: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: ruby


### PR DESCRIPTION
What
----

Adds dependabot configuration

Why
---

So dependencies are updated automatically, and so maintainers are notified of vulnerabilities