### PR TITLE
ci: bump registry tag resource version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,7 +5,7 @@ resource_types:
     type: registry-image
     source:
       repository: tlwr/registry-tag-resource
-      tag: 1593696431
+      tag: 6d98ababb33b88eb6d9a0d3d2824c3efe500c18b
 
 resources:
   - name: ruby-img-tag


### PR DESCRIPTION
What
----

Bumps registry-tag resource version in CI pipeline


![](https://nerdbot.com/wp-content/uploads/2020/05/Screenshot-2020-05-26-at-2.40.26-PM.png)

Why
---

Use the latest version of ruby and dependencies