### PR TITLE
ci: check more registry pages less often

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,10 +11,10 @@ resources:
   - name: ruby-img-tag
     type: registry-tag
     icon: tag
-    check_every: 15m
+    check_every: 60m
     source:
       uri: https://hub.docker.com/v2/repositories/library/ruby
-      pages: 3
+      pages: 10
       regexp: '^[0-9]+[.][0-9]+[.][0-9]+-alpine$'
       semver:
         matcher: '>= 3.0'


### PR DESCRIPTION
What
----

Increase number of pages fetched by registry-tag-resource

Check resource less often

Why
---

Ruby publishes loads of tags, so the first three pages do not always yield an alpine version